### PR TITLE
아이템 리밸런싱

### DIFF
--- a/src/main/java/com/dace/vanillaplus/VanillaPlus.java
+++ b/src/main/java/com/dace/vanillaplus/VanillaPlus.java
@@ -1,5 +1,6 @@
 package com.dace.vanillaplus;
 
+import com.dace.vanillaplus.sound.SoundEventManager;
 import com.dace.vanillaplus.util.ReflectionUtil;
 import com.mojang.logging.LogUtils;
 import net.minecraftforge.fml.common.Mod;
@@ -18,5 +19,6 @@ public final class VanillaPlus {
         LOGGER.debug("Hello, World!");
 
         ReflectionUtil.loadClass(Tag.class);
+        ReflectionUtil.loadClass(SoundEventManager.class);
     }
 }

--- a/src/main/java/com/dace/vanillaplus/item/RecoveryCompassItem.java
+++ b/src/main/java/com/dace/vanillaplus/item/RecoveryCompassItem.java
@@ -1,0 +1,109 @@
+package com.dace.vanillaplus.item;
+
+import com.dace.vanillaplus.sound.SoundEventManager;
+import lombok.NonNull;
+import net.minecraft.client.Minecraft;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.GlobalPos;
+import net.minecraft.core.particles.ParticleTypes;
+import net.minecraft.network.chat.Component;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.sounds.SoundEvents;
+import net.minecraft.sounds.SoundSource;
+import net.minecraft.stats.Stats;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.InteractionResult;
+import net.minecraft.world.effect.MobEffectInstance;
+import net.minecraft.world.effect.MobEffects;
+import net.minecraft.world.entity.Relative;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.portal.TeleportTransition;
+import net.minecraft.world.phys.Vec3;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * 만회 나침반 아이템 클래스.
+ */
+public final class RecoveryCompassItem extends Item {
+    public RecoveryCompassItem(@NonNull Properties properties) {
+        super(properties);
+    }
+
+    /**
+     * 사용 효과를 재생한다.
+     *
+     * @param serverLevel 월드
+     * @param pos         위치
+     */
+    private static void playUseEffects(@NonNull ServerLevel serverLevel, @NonNull Vec3 pos) {
+        serverLevel.playSound(null, pos.x, pos.y, pos.z, SoundEventManager.RECOVERY_COMPASS_TELEPORT, SoundSource.PLAYERS, 2.0F, 1.0F);
+        serverLevel.playSound(null, pos.x, pos.y, pos.z, SoundEvents.PLAYER_TELEPORT, SoundSource.PLAYERS, 2.0F, 0.5F);
+
+        serverLevel.sendParticles(ParticleTypes.SONIC_BOOM, pos.x, pos.y, pos.z, 1, 0, 0, 0, 0);
+    }
+
+    @Override
+    @NonNull
+    public InteractionResult use(@NonNull Level level, @NonNull Player player, @NonNull InteractionHand interactionHand) {
+        if (!(level instanceof ServerLevel serverLevel))
+            return InteractionResult.PASS;
+
+        GlobalPos lastDeathPos = player.getLastDeathLocation().orElse(null);
+        if (lastDeathPos == null)
+            return InteractionResult.FAIL;
+
+        Vec3 pos = getTeleportLocation(serverLevel, lastDeathPos);
+        if (pos == null) {
+            player.displayClientMessage(Component.translatable("item.minecraft.recovery_compass.teleport_not_valid"), true);
+            return InteractionResult.FAIL;
+        }
+
+        Vec3 oldPos = player.position();
+
+        player.teleport(new TeleportTransition(serverLevel, pos, Vec3.ZERO, 0, 0,
+                Relative.union(Relative.ROTATION, Relative.DELTA), TeleportTransition.DO_NOTHING));
+
+        playUseEffects(serverLevel, oldPos);
+        playUseEffects(serverLevel, pos);
+
+        Minecraft.getInstance().gameRenderer.displayItemActivation(getDefaultInstance());
+
+        player.resetFallDistance();
+        player.addEffect(new MobEffectInstance(MobEffects.RESISTANCE, 100, 3));
+
+        if (player instanceof ServerPlayer)
+            player.resetCurrentImpulseContext();
+
+        player.awardStat(Stats.ITEM_USED.get(this));
+        player.getItemInHand(interactionHand).consume(1, player);
+
+        return InteractionResult.SUCCESS_SERVER;
+    }
+
+    /**
+     * 이동할 위치를 반환한다.
+     *
+     * @param serverLevel 월드
+     * @param globalPos   전역 위치
+     * @return 이동할 위치. 이동할 수 없으면 {@code null} 반환
+     */
+    @Nullable
+    private Vec3 getTeleportLocation(@NonNull ServerLevel serverLevel, @NonNull GlobalPos globalPos) {
+        if (globalPos.dimension() != serverLevel.dimension())
+            return null;
+
+        BlockPos blockPos = globalPos.pos();
+        while (blockPos.getY() > serverLevel.getMinY()) {
+            BlockPos belowBlockPos = blockPos.below();
+            if (serverLevel.getBlockState(belowBlockPos).blocksMotion())
+                return blockPos.getBottomCenter();
+
+            blockPos = belowBlockPos;
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/com/dace/vanillaplus/item/RecoveryCompassItem.java
+++ b/src/main/java/com/dace/vanillaplus/item/RecoveryCompassItem.java
@@ -1,8 +1,9 @@
 package com.dace.vanillaplus.item;
 
+import com.dace.vanillaplus.network.NetworkManager;
+import com.dace.vanillaplus.network.packet.RecoveryCompassTeleportPacketHandler;
 import com.dace.vanillaplus.sound.SoundEventManager;
 import lombok.NonNull;
-import net.minecraft.client.Minecraft;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.GlobalPos;
 import net.minecraft.core.particles.ParticleTypes;
@@ -69,7 +70,8 @@ public final class RecoveryCompassItem extends Item {
         playUseEffects(serverLevel, oldPos);
         playUseEffects(serverLevel, pos);
 
-        Minecraft.getInstance().gameRenderer.displayItemActivation(getDefaultInstance());
+        if (player instanceof ServerPlayer serverPlayer)
+            NetworkManager.sendToPlayer(new RecoveryCompassTeleportPacketHandler(), serverPlayer);
 
         player.resetFallDistance();
         player.addEffect(new MobEffectInstance(MobEffects.RESISTANCE, 100, 3));

--- a/src/main/java/com/dace/vanillaplus/mixin/ArmorMaterialsMixin.java
+++ b/src/main/java/com/dace/vanillaplus/mixin/ArmorMaterialsMixin.java
@@ -1,0 +1,26 @@
+package com.dace.vanillaplus.mixin;
+
+import com.dace.vanillaplus.rebalance.Rebalance;
+import net.minecraft.world.item.equipment.ArmorMaterials;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
+import org.spongepowered.asm.mixin.injection.ModifyArgs;
+import org.spongepowered.asm.mixin.injection.invoke.arg.Args;
+
+@Mixin(ArmorMaterials.class)
+public interface ArmorMaterialsMixin {
+    @ModifyArg(method = "<clinit>", at = @At(value = "INVOKE",
+            target = "Lnet/minecraft/world/item/equipment/ArmorMaterial;<init>(ILjava/util/Map;ILnet/minecraft/core/Holder;FFLnet/minecraft/tags/TagKey;Lnet/minecraft/resources/ResourceKey;)V",
+            ordinal = 1), index = 2)
+    private static int modifyChainmailEnchantability(int enchantability) {
+        return Rebalance.Chainmail.ENCHANTABILITY;
+    }
+
+    @ModifyArgs(method = "<clinit>", at = @At(value = "INVOKE",
+            target = "Lnet/minecraft/world/item/equipment/ArmorMaterials;makeDefense(IIIII)Ljava/util/Map;", ordinal = 1))
+    private static void modifyChainmailDefense(Args args) {
+        for (int i = 0; i < 4; i++)
+            args.set(i, Rebalance.Chainmail.DEFENSE.get(i));
+    }
+}

--- a/src/main/java/com/dace/vanillaplus/mixin/BedBlockMixin.java
+++ b/src/main/java/com/dace/vanillaplus/mixin/BedBlockMixin.java
@@ -19,7 +19,7 @@ public abstract class BedBlockMixin {
             target = "Lnet/minecraft/world/level/Level;removeBlock(Lnet/minecraft/core/BlockPos;Z)Z", ordinal = 0), cancellable = true)
     private void preventUseIfCannotUse(BlockState blockState, Level level, BlockPos blockPos, Player player, BlockHitResult blockHitResult,
                                        CallbackInfoReturnable<InteractionResult> cir) {
-        player.displayClientMessage(Component.translatable("block.vanillaplus.bed.no_use"), true);
+        player.displayClientMessage(Component.translatable("block.minecraft.bed.no_use"), true);
         cir.setReturnValue(InteractionResult.SUCCESS_SERVER);
     }
 }

--- a/src/main/java/com/dace/vanillaplus/mixin/DeathProtectionMixin.java
+++ b/src/main/java/com/dace/vanillaplus/mixin/DeathProtectionMixin.java
@@ -1,0 +1,19 @@
+package com.dace.vanillaplus.mixin;
+
+import com.dace.vanillaplus.rebalance.Rebalance;
+import net.minecraft.world.effect.MobEffectInstance;
+import net.minecraft.world.item.component.DeathProtection;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
+
+import java.util.List;
+
+@Mixin(DeathProtection.class)
+public abstract class DeathProtectionMixin {
+    @ModifyArg(method = "<clinit>", at = @At(value = "INVOKE",
+            target = "Lnet/minecraft/world/item/consume_effects/ApplyStatusEffectsConsumeEffect;<init>(Ljava/util/List;)V"))
+    private static List<MobEffectInstance> modifyTotemMobEffects(List<MobEffectInstance> par1) {
+        return Rebalance.Totem.MOB_EFFECTS;
+    }
+}

--- a/src/main/java/com/dace/vanillaplus/mixin/ItemsMixin.java
+++ b/src/main/java/com/dace/vanillaplus/mixin/ItemsMixin.java
@@ -1,14 +1,31 @@
 package com.dace.vanillaplus.mixin;
 
+import com.dace.vanillaplus.item.RecoveryCompassItem;
 import com.dace.vanillaplus.rebalance.Rebalance;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.Items;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.ModifyArg;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import java.util.function.Function;
 
 @Mixin(Items.class)
 public abstract class ItemsMixin {
+    @Shadow
+    public static Item registerItem(String name, Function<Item.Properties, Item> itemFunction, Item.Properties properties) {
+        return null;
+    }
+
+    @Redirect(method = "<clinit>", at = @At(value = "INVOKE",
+            target = "Lnet/minecraft/world/item/Items;registerItem(Ljava/lang/String;Lnet/minecraft/world/item/Item$Properties;)Lnet/minecraft/world/item/Item;",
+            ordinal = 75))
+    private static Item registerRecoveryCompassItem(String name, Item.Properties properties) {
+        return registerItem(name, RecoveryCompassItem::new, properties);
+    }
+
     @ModifyArg(method = "<clinit>", at = @At(value = "INVOKE",
             target = "Lnet/minecraft/world/item/Item$Properties;durability(I)Lnet/minecraft/world/item/Item$Properties;", ordinal = 8))
     private static int modifyShieldDurability(int durability) {

--- a/src/main/java/com/dace/vanillaplus/mixin/LivingEntityMixin.java
+++ b/src/main/java/com/dace/vanillaplus/mixin/LivingEntityMixin.java
@@ -1,9 +1,15 @@
 package com.dace.vanillaplus.mixin;
 
+import com.llamalad7.mixinextras.expression.Definition;
+import com.llamalad7.mixinextras.expression.Expression;
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import com.llamalad7.mixinextras.sugar.Local;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.ai.Brain;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.component.DeathProtection;
 import net.minecraft.world.level.ClipContext;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -11,6 +17,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyArg;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(LivingEntity.class)
 public abstract class LivingEntityMixin extends EntityMixin {
@@ -32,6 +39,18 @@ public abstract class LivingEntityMixin extends EntityMixin {
 
     @Inject(method = "die", at = @At("TAIL"))
     protected void onDie(DamageSource damageSource, CallbackInfo ci) {
+        // 미사용
+    }
+
+    @Definition(id = "deathprotection", local = @Local(type = DeathProtection.class))
+    @Expression("deathprotection != null")
+    @ModifyExpressionValue(method = "checkTotemDeathProtection", at = @At(value = "MIXINEXTRAS:EXPRESSION", ordinal = 0))
+    protected boolean canUseTotem(boolean canUse, @Local(ordinal = 1) ItemStack itemStack) {
+        return canUse;
+    }
+
+    @Inject(method = "checkTotemDeathProtection", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/LivingEntity;setHealth(F)V"))
+    protected void onUseTotem(DamageSource damageSource, CallbackInfoReturnable<Boolean> cir, @Local ItemStack itemStack) {
         // 미사용
     }
 }

--- a/src/main/java/com/dace/vanillaplus/mixin/PlayerMixin.java
+++ b/src/main/java/com/dace/vanillaplus/mixin/PlayerMixin.java
@@ -1,21 +1,29 @@
 package com.dace.vanillaplus.mixin;
 
 import com.dace.vanillaplus.custom.CustomPlayer;
+import com.dace.vanillaplus.rebalance.Rebalance;
 import com.llamalad7.mixinextras.injector.ModifyReturnValue;
+import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.entity.Pose;
 import net.minecraft.world.entity.player.Abilities;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemCooldowns;
+import net.minecraft.world.item.ItemStack;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(Player.class)
 public abstract class PlayerMixin extends LivingEntityMixin implements CustomPlayer {
     @Shadow
     @Final
     private Abilities abilities;
+    @Shadow
+    @Final
+    private ItemCooldowns cooldowns;
     @Unique
     private boolean vp$isProneKeyDown = false;
 
@@ -27,5 +35,15 @@ public abstract class PlayerMixin extends LivingEntityMixin implements CustomPla
     @ModifyReturnValue(method = "getDesiredPose", at = @At(value = "RETURN", ordinal = 4))
     private Pose modifyDesiredPose(Pose pose) {
         return vp$isProneKeyDown && !abilities.flying && onGround() ? Pose.SWIMMING : pose;
+    }
+
+    @Override
+    protected boolean canUseTotem(boolean canUse, ItemStack itemStack) {
+        return canUse && !cooldowns.isOnCooldown(itemStack);
+    }
+
+    @Override
+    protected void onUseTotem(DamageSource damageSource, CallbackInfoReturnable<Boolean> cir, ItemStack itemStack) {
+        cooldowns.addCooldown(itemStack, Rebalance.Totem.COOLDOWN_SECONDS * 20);
     }
 }

--- a/src/main/java/com/dace/vanillaplus/network/NetworkManager.java
+++ b/src/main/java/com/dace/vanillaplus/network/NetworkManager.java
@@ -3,13 +3,18 @@ package com.dace.vanillaplus.network;
 import com.dace.vanillaplus.VanillaPlus;
 import com.dace.vanillaplus.network.packet.PacketHandler;
 import com.dace.vanillaplus.network.packet.PronePacketHandler;
+import com.dace.vanillaplus.network.packet.RecoveryCompassTeleportPacketHandler;
 import lombok.NonNull;
+import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.network.protocol.PacketFlow;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraftforge.network.ChannelBuilder;
 import net.minecraftforge.network.PacketDistributor;
 import net.minecraftforge.network.SimpleChannel;
+
+import java.util.function.Function;
 
 /**
  * 네트워크 관련 기능을 제공하는 클래스.
@@ -28,11 +33,24 @@ public final class NetworkManager {
      * 패킷 전송 채널을 등록한다.
      */
     public static void register() {
-        CHANNEL.play().serverbound(simpleFlow ->
-                simpleFlow.add(PronePacketHandler.class, StreamCodec.of((buf, packet) -> packet.encode(buf),
-                        PronePacketHandler::new), PronePacketHandler::handle));
+        registerPacket(PacketFlow.SERVERBOUND, PronePacketHandler.class, PronePacketHandler::new);
+        registerPacket(PacketFlow.CLIENTBOUND, RecoveryCompassTeleportPacketHandler.class, buf -> new RecoveryCompassTeleportPacketHandler());
 
         CHANNEL.build();
+    }
+
+    /**
+     * 지정한 서버 패킷 처리기를 등록한다.
+     *
+     * @param packetFlow         패킷 유형 (클라이언트 및 서버)
+     * @param packetHandlerClass 패킷 처리기 클래스
+     * @param packetFunction     패킷 처리기 반환에 실행할 작업
+     * @param <T>                {@link PacketHandler}를 상속받는 패킷 처리기
+     */
+    private static <T extends PacketHandler> void registerPacket(@NonNull PacketFlow packetFlow, @NonNull Class<T> packetHandlerClass,
+                                                                 @NonNull Function<RegistryFriendlyByteBuf, T> packetFunction) {
+        CHANNEL.play().flow(packetFlow).add(packetHandlerClass, StreamCodec.of((buf, packet) -> packet.encode(buf),
+                packetFunction::apply), PacketHandler::handle);
     }
 
     /**

--- a/src/main/java/com/dace/vanillaplus/network/packet/RecoveryCompassTeleportPacketHandler.java
+++ b/src/main/java/com/dace/vanillaplus/network/packet/RecoveryCompassTeleportPacketHandler.java
@@ -1,0 +1,24 @@
+package com.dace.vanillaplus.network.packet;
+
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import net.minecraft.client.Minecraft;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.world.item.Items;
+import net.minecraftforge.event.network.CustomPayloadEvent;
+
+/**
+ * 만회 나침반 사용 패킷을 처리하는 클래스.
+ */
+@NoArgsConstructor
+public final class RecoveryCompassTeleportPacketHandler implements PacketHandler {
+    @Override
+    public void encode(@NonNull FriendlyByteBuf buf) {
+        // 미사용
+    }
+
+    @Override
+    public void handle(@NonNull CustomPayloadEvent.Context context) {
+        Minecraft.getInstance().gameRenderer.displayItemActivation(Items.RECOVERY_COMPASS.getDefaultInstance());
+    }
+}

--- a/src/main/java/com/dace/vanillaplus/rebalance/Rebalance.java
+++ b/src/main/java/com/dace/vanillaplus/rebalance/Rebalance.java
@@ -20,6 +20,7 @@ import net.minecraft.tags.StructureTags;
 import net.minecraft.tags.TagKey;
 import net.minecraft.util.ARGB;
 import net.minecraft.util.RandomSource;
+import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.effect.MobEffects;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.animal.axolotl.Axolotl;
@@ -116,6 +117,20 @@ public final class Rebalance {
         public static final int ENCHANTABILITY = 18;
         /** 방어력 (부츠, 레깅스, 갑옷, 투구) (원본: 1, 4, 5, 2) */
         public static final List<Integer> DEFENSE = List.of(2, 5, 6, 2);
+    }
+
+    /**
+     * 불사의 토템 설정.
+     */
+    @UtilityClass
+    public static final class Totem {
+        /** 쿨타임 */
+        public static final int COOLDOWN_SECONDS = 10;
+        /** 상태 효과 목록 (원본: 재생 II 45초, 흡수 II 5초, 화염 저항 40초) */
+        public static final List<MobEffectInstance> MOB_EFFECTS = List.of(
+                new MobEffectInstance(MobEffects.REGENERATION, 10 * 20, 1),
+                new MobEffectInstance(MobEffects.ABSORPTION, 5 * 20, 1),
+                new MobEffectInstance(MobEffects.FIRE_RESISTANCE, 10 * 20, 0));
     }
 
     /**

--- a/src/main/java/com/dace/vanillaplus/rebalance/Rebalance.java
+++ b/src/main/java/com/dace/vanillaplus/rebalance/Rebalance.java
@@ -108,6 +108,17 @@ public final class Rebalance {
     }
 
     /**
+     * 사슬 갑옷 설정.
+     */
+    @UtilityClass
+    public static final class Chainmail {
+        /** 마법 부여 가중치 (원본: 12) */
+        public static final int ENCHANTABILITY = 18;
+        /** 방어력 (부츠, 레깅스, 갑옷, 투구) (원본: 1, 4, 5, 2) */
+        public static final List<Integer> DEFENSE = List.of(2, 5, 6, 2);
+    }
+
+    /**
      * 주민 거래 설정.
      */
     @UtilityClass

--- a/src/main/java/com/dace/vanillaplus/sound/SoundEventManager.java
+++ b/src/main/java/com/dace/vanillaplus/sound/SoundEventManager.java
@@ -1,0 +1,27 @@
+package com.dace.vanillaplus.sound;
+
+import com.dace.vanillaplus.VanillaPlus;
+import lombok.NonNull;
+import lombok.experimental.UtilityClass;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.sounds.SoundEvent;
+import net.minecraftforge.registries.DeferredRegister;
+
+/**
+ * 효과음 이벤트를 관리하는 클래스.
+ */
+@UtilityClass
+public final class SoundEventManager {
+    private static final DeferredRegister<SoundEvent> SOUND_EVENTS = DeferredRegister.create(Registries.SOUND_EVENT, VanillaPlus.MODID);
+
+    public static final SoundEvent RECOVERY_COMPASS_TELEPORT = create("item.recovery_compass.teleport");
+
+    @NonNull
+    private static SoundEvent create(@NonNull String name) {
+        SoundEvent soundEvent = SoundEvent.createVariableRangeEvent(ResourceLocation.fromNamespaceAndPath(VanillaPlus.MODID, name));
+        SOUND_EVENTS.register(name, () -> soundEvent);
+
+        return soundEvent;
+    }
+}

--- a/src/main/resources/assets/vanillaplus/lang/en_us.json
+++ b/src/main/resources/assets/vanillaplus/lang/en_us.json
@@ -1,10 +1,11 @@
 {
-  "block.vanillaplus.bed.no_use": "You cannot sleep here.",
+  "block.minecraft.bed.no_use": "You cannot sleep here",
   "filled_map.ancient_city": "Ancient City Explorer Map",
   "filled_map.explorer_desert": "Desert Explorer Map",
   "filled_map.explorer_snowy": "Snowy Explorer Map",
   "filled_map.mineshaft": "Mineshaft Explorer Map",
   "filled_map.pillager_outpost": "Pillager Outpost Explorer Map",
+  "item.minecraft.recovery_compass.teleport_not_valid": "Your last death location was invalid or in different dimension",
   "key.prone": "Prone",
   "merchant.closed": "Villager closed the store. Please come back later.",
   "merchant.out_of_stock": "Currently out of stock. Please come back later.",
@@ -12,5 +13,6 @@
   "potion.potency.6": "VII",
   "potion.potency.7": "VIII",
   "potion.potency.8": "IX",
-  "potion.potency.9": "X"
+  "potion.potency.9": "X",
+  "subtitles.item.recovery_compass.teleport": "Recovery Compass activates"
 }

--- a/src/main/resources/assets/vanillaplus/lang/ko_kr.json
+++ b/src/main/resources/assets/vanillaplus/lang/ko_kr.json
@@ -1,10 +1,11 @@
 {
-  "block.vanillaplus.bed.no_use": "여기서 잘 수 없습니다.",
+  "block.minecraft.bed.no_use": "여기서 잘 수 없습니다",
   "filled_map.ancient_city": "고대 도시 탐험가 지도",
   "filled_map.explorer_desert": "사막 탐험가 지도",
   "filled_map.explorer_snowy": "설원 탐험가 지도",
   "filled_map.mineshaft": "폐광 탐험가 지도",
   "filled_map.pillager_outpost": "약탈자 전초기지 탐험가 지도",
+  "item.minecraft.recovery_compass.teleport_not_valid": "마지막으로 죽은 위치가 유효하지 않거나 다른 차원에 있습니다",
   "key.prone": "엎드리기",
   "merchant.closed": "주민이 상점을 마감했습니다. 나중에 다시 오세요.",
   "merchant.out_of_stock": "현재 재고가 없습니다. 나중에 다시 오세요.",
@@ -12,5 +13,6 @@
   "potion.potency.6": "VII",
   "potion.potency.7": "VIII",
   "potion.potency.8": "IX",
-  "potion.potency.9": "X"
+  "potion.potency.9": "X",
+  "subtitles.item.recovery_compass.teleport": "만회 나침반이 작동함"
 }

--- a/src/main/resources/assets/vanillaplus/sounds.json
+++ b/src/main/resources/assets/vanillaplus/sounds.json
@@ -1,0 +1,23 @@
+{
+  "item.recovery_compass.teleport": {
+    "subtitle": "subtitles.item.recovery_compass.teleport",
+    "sounds": [
+      {
+        "name": "mob/warden/sonic_boom1",
+        "pitch": 1.4
+      },
+      {
+        "name": "mob/warden/sonic_boom2",
+        "pitch": 1.4
+      },
+      {
+        "name": "mob/warden/sonic_boom3",
+        "pitch": 1.4
+      },
+      {
+        "name": "mob/warden/sonic_boom4",
+        "pitch": 1.4
+      }
+    ]
+  }
+}

--- a/src/main/resources/data/minecraft/enchantment/impaling.json
+++ b/src/main/resources/data/minecraft/enchantment/impaling.json
@@ -10,7 +10,7 @@
           "type": "minecraft:add",
           "value": {
             "type": "minecraft:linear",
-            "base": 1.5,
+            "base": 1.0,
             "per_level_above_first": 1.0
           }
         },
@@ -41,10 +41,7 @@
               "predicate": {
                 "location": {
                   "fluid": {
-                    "fluids": [
-                      "minecraft:water",
-                      "minecraft:flowing_water"
-                    ]
+                    "fluids": "#minecraft:water"
                   }
                 }
               }

--- a/src/main/resources/data/minecraft/enchantment/thorns.json
+++ b/src/main/resources/data/minecraft/enchantment/thorns.json
@@ -1,0 +1,51 @@
+{
+  "anvil_cost": 8,
+  "description": {
+    "translate": "enchantment.minecraft.thorns"
+  },
+  "effects": {
+    "minecraft:post_attack": [
+      {
+        "affected": "attacker",
+        "effect": {
+          "type": "minecraft:all_of",
+          "effects": [
+            {
+              "type": "minecraft:damage_entity",
+              "damage_type": "minecraft:thorns",
+              "max_damage": 6.0,
+              "min_damage": 3.0
+            }
+          ]
+        },
+        "enchanted": "victim",
+        "requirements": {
+          "chance": {
+            "type": "minecraft:enchantment_level",
+            "amount": {
+              "type": "minecraft:linear",
+              "base": 0.15,
+              "per_level_above_first": 0.15
+            }
+          },
+          "condition": "minecraft:random_chance"
+        }
+      }
+    ]
+  },
+  "max_cost": {
+    "base": 60,
+    "per_level_above_first": 20
+  },
+  "max_level": 3,
+  "min_cost": {
+    "base": 10,
+    "per_level_above_first": 20
+  },
+  "primary_items": "#minecraft:enchantable/chest_armor",
+  "slots": [
+    "any"
+  ],
+  "supported_items": "#minecraft:enchantable/armor",
+  "weight": 1
+}

--- a/src/main/resources/vanillaplus.mixins.json
+++ b/src/main/resources/vanillaplus.mixins.json
@@ -15,6 +15,7 @@
     "CreakingMixin",
     "CreativeModeTabsMixin",
     "CrossbowItemMixin",
+    "DeathProtectionMixin",
     "EntityMixin",
     "ExperienceOrbMixin",
     "FireworkRocketEntityMixin",

--- a/src/main/resources/vanillaplus.mixins.json
+++ b/src/main/resources/vanillaplus.mixins.json
@@ -8,6 +8,7 @@
     "AbstractFurnaceBlockEntityMixin",
     "AbstractVillagerMixin",
     "AnvilMenuMixin",
+    "ArmorMaterialsMixin",
     "BedBlockMixin",
     "BlocksMixin",
     "CreakingHeartBlockMixin",


### PR DESCRIPTION
- 모든 Mixin 클래스를 추상 클래스로 변경
- 사슬 갑옷의 마법 부여 가중치 및 방어력 증가
- 찌르기 인첸트 피해 증가량 조정
- 불사의 토템 쿨타임 추가, 상태 효과 지속시간 감소
- 만회 나침반 사용 시 죽은 위치로 순간이동 및 저항 버프 지급
- 가시 인첸트의 피해량 증가, 추가 내구도 감소 제거